### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,8 +12,8 @@ image::https://codecov.io/gh/{org}/{repo}/branch/{branch}/graph/badge.svg["codec
 :org: spring-cloud
 :repo: spring-cloud-release-tools
 :github-repo: {org}/{repo}
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :toc: left
 :toclevels: 8
 :nofooter:
@@ -50,7 +50,7 @@ After project release
 - Generates a blog template under `target/blog.md` (ONLY FOR NON-SNAPSHOT VERSIONS)
 - Generates a tweet template under `target/tweet.txt` (ONLY FOR NON-SNAPSHOT VERSIONS)
 - Generates a release notes template under `target/notes.md` (ONLY FOR NON-SNAPSHOT VERSIONS)
-- Updates project information in Sagan (http://spring.io) (ONLY FOR SNAPSHOT / RELEASE VERSIONS)
+- Updates project information in Sagan (https://spring.io) (ONLY FOR SNAPSHOT / RELEASE VERSIONS)
 - For `GA`/ `SR` release will create an issue in Spring Guides under https://github.com/spring-guides/getting-started-guides/issues/
 - For `GA`/ `SR` release will update the links under https://github.com/spring-cloud/spring-cloud-static/tree/gh-pages/current
 
@@ -325,7 +325,7 @@ folder and run your application like this:
 
 [source,bash]
 ----
-$ wget http://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O ../spring-cloud-release-tools-spring-1.0.0.M1.jar
+$ wget https://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O ../spring-cloud-release-tools-spring-1.0.0.M1.jar
 $ java -jar target/spring-cloud-release-tools-spring-1.0.0.M1.jar --spring.config.name=releaser
 ----
 
@@ -356,7 +356,7 @@ each release
 ----
 $ export RELEASER_POM_BRANCH=Dalston.RELEASE
 $ export RELEASER_GIT_OAUTH_TOKEN=...
-$ wget http://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O spring-cloud-release-tools-spring-1.0.0.M1.jar
+$ wget https://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O spring-cloud-release-tools-spring-1.0.0.M1.jar
 $ java -jar target/spring-cloud-release-tools-spring-1.0.0.M1.jar --releaser.working-dir=/path/to/project/root
 ----
 

--- a/docs/src/main/asciidoc/spring-cloud-release-tools.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-release-tools.adoc
@@ -2,8 +2,8 @@
 :org: spring-cloud
 :repo: spring-cloud-release-tools
 :github-repo: {org}/{repo}
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :toc: left
 :toclevels: 8
 :nofooter:
@@ -40,7 +40,7 @@ After project release
 - Generates a blog template under `target/blog.md` (ONLY FOR NON-SNAPSHOT VERSIONS)
 - Generates a tweet template under `target/tweet.txt` (ONLY FOR NON-SNAPSHOT VERSIONS)
 - Generates a release notes template under `target/notes.md` (ONLY FOR NON-SNAPSHOT VERSIONS)
-- Updates project information in Sagan (http://spring.io) (ONLY FOR SNAPSHOT / RELEASE VERSIONS)
+- Updates project information in Sagan (https://spring.io) (ONLY FOR SNAPSHOT / RELEASE VERSIONS)
 - For `GA`/ `SR` release will create an issue in Spring Guides under https://github.com/spring-guides/getting-started-guides/issues/
 - For `GA`/ `SR` release will update the links under https://github.com/spring-cloud/spring-cloud-static/tree/gh-pages/current
 
@@ -318,7 +318,7 @@ folder and run your application like this:
 
 [source,bash]
 ----
-$ wget http://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O ../spring-cloud-release-tools-spring-1.0.0.M1.jar
+$ wget https://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O ../spring-cloud-release-tools-spring-1.0.0.M1.jar
 $ java -jar target/spring-cloud-release-tools-spring-1.0.0.M1.jar --spring.config.name=releaser
 ----
 
@@ -349,7 +349,7 @@ each release
 ----
 $ export RELEASER_POM_BRANCH=Dalston.RELEASE
 $ export RELEASER_GIT_OAUTH_TOKEN=...
-$ wget http://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O spring-cloud-release-tools-spring-1.0.0.M1.jar
+$ wget https://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar -O spring-cloud-release-tools-spring-1.0.0.M1.jar
 $ java -jar target/spring-cloud-release-tools-spring-1.0.0.M1.jar --releaser.working-dir=/path/to/project/root
 ----
 

--- a/spring-cloud-release-tools-core/src/main/java/org/springframework/cloud/release/internal/docs/DocumentationUpdater.java
+++ b/spring-cloud-release-tools-core/src/main/java/org/springframework/cloud/release/internal/docs/DocumentationUpdater.java
@@ -16,7 +16,7 @@ import org.springframework.cloud.release.internal.pom.ProjectVersion;
  */
 public class DocumentationUpdater {
 
-	private static final String SC_STATIC_URL = "http://cloud.spring.io/spring-cloud-static/";
+	private static final String SC_STATIC_URL = "https://cloud.spring.io/spring-cloud-static/";
 	private static final Logger log = LoggerFactory.getLogger(DocumentationUpdater.class);
 
 	private final ProjectGitHandler gitHandler;

--- a/spring-cloud-release-tools-core/src/main/java/org/springframework/cloud/release/internal/sagan/SaganUpdater.java
+++ b/spring-cloud-release-tools-core/src/main/java/org/springframework/cloud/release/internal/sagan/SaganUpdater.java
@@ -100,13 +100,13 @@ public class SaganUpdater {
 	private String referenceUrl(String branch, ProjectVersion version) {
 		if (!version.isSnapshot()) {
 			// static/sleuth/{version}/
-			return "http://cloud.spring.io/spring-cloud-static/" + version.projectName + "/{version}/";
+			return "https://cloud.spring.io/spring-cloud-static/" + version.projectName + "/{version}/";
 		}
 		if (branch.toLowerCase().contains("master")) {
 			// sleuth/
-			return "http://cloud.spring.io/" + version.projectName + "/" + version.projectName + ".html";
+			return "https://cloud.spring.io/" + version.projectName + "/" + version.projectName + ".html";
 		}
 		// sleuth/1.1.x/
-		return "http://cloud.spring.io/" + version.projectName + "/" + branch + "/";
+		return "https://cloud.spring.io/" + version.projectName + "/" + branch + "/";
 	}
 }

--- a/spring-cloud-release-tools-core/src/main/java/org/springframework/cloud/release/internal/template/BlogTemplateGenerator.java
+++ b/spring-cloud-release-tools-core/src/main/java/org/springframework/cloud/release/internal/template/BlogTemplateGenerator.java
@@ -46,7 +46,7 @@ class BlogTemplateGenerator {
 			// availability - General Availability (RELEASE) / Service Release 1 (SR1) / Milestone 1 (M1)
 			// releaseName - Dalston
 			// releaseLink
-			// - [Maven Central](http://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/Dalston.RELEASE/)
+			// - [Maven Central](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/Dalston.RELEASE/)
 			// - [Spring Milestone](https://repo.spring.io/milestone/) repository
 			// releaseVersion '- Dalston.RELEASE
 			boolean release = this.releaseVersion.contains("RELEASE");
@@ -117,7 +117,7 @@ class BlogTemplateGenerator {
 		if (nonRelease) {
 			return "[Spring Milestone](https://repo.spring.io/milestone/) repository";
 		}
-		return "[Maven Central](http://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/" + this.releaseVersion + "/)";
+		return "[Maven Central](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/" + this.releaseVersion + "/)";
 	}
 }
 

--- a/spring-cloud-release-tools-core/src/main/resources/templates/cloud/blog.hbs
+++ b/spring-cloud-release-tools-core/src/main/resources/templates/cloud/blog.hbs
@@ -14,7 +14,7 @@ The following modules were updated as part of {{ releaseVersion }}:
 {{#each projects}}| {{name}}        	| {{version}}  	|
 {{/each}}
 
-As always, we welcome feedback on [GitHub](https://github.com/spring-cloud/), on [Gitter](https://gitter.im/spring-cloud/spring-cloud), on [Stack Overflow](http://stackoverflow.com/questions/tagged/spring-cloud), or on [Twitter](https://twitter.com/SpringCloud).
+As always, we welcome feedback on [GitHub](https://github.com/spring-cloud/), on [Gitter](https://gitter.im/spring-cloud/spring-cloud), on [Stack Overflow](https://stackoverflow.com/questions/tagged/spring-cloud), or on [Twitter](https://twitter.com/SpringCloud).
 
 To get started with Maven with a BOM (dependency management only):
 
@@ -23,7 +23,7 @@ To get started with Maven with a BOM (dependency management only):
     <repository>
         <id>spring-milestones</id>
         <name>Spring Milestones</name>
-        <url>http://repo.spring.io/milestone</url>
+        <url>https://repo.spring.io/milestone</url>
         <snapshots>
             <enabled>false</enabled>
         </snapshots>
@@ -64,7 +64,7 @@ buildscript {
 
 {{#if nonRelease}}repositories {
     maven {
-        url 'http://repo.spring.io/milestone'
+        url 'https://repo.spring.io/milestone'
     }
 }{{/if}}
 

--- a/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/docs/DocumentationUpdaterTests.java
+++ b/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/docs/DocumentationUpdaterTests.java
@@ -102,7 +102,7 @@ public class DocumentationUpdaterTests {
 		String indexHtmlContent = new String(Files.readAllBytes(
 				new File(updatedDocs, "current/index.html").toPath()));
 		then(indexHtmlContent)
-				.doesNotContain("http://cloud.spring.io/spring-cloud-static/Angel.SR33/");
+				.doesNotContain("https://cloud.spring.io/spring-cloud-static/Angel.SR33/");
 	}
 
 	@Test
@@ -133,7 +133,7 @@ public class DocumentationUpdaterTests {
 		String indexHtmlContent = new String(Files.readAllBytes(
 				new File(updatedDocs, "current/index.html").toPath()));
 		then(indexHtmlContent)
-				.doesNotContain("http://cloud.spring.io/spring-cloud-static/Angel.SR33/");
+				.doesNotContain("https://cloud.spring.io/spring-cloud-static/Angel.SR33/");
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class DocumentationUpdaterTests {
 		String indexHtmlContent = new String(Files.readAllBytes(
 				new File(updatedDocs, "current/index.html").toPath()));
 		then(indexHtmlContent)
-				.contains("http://cloud.spring.io/spring-cloud-static/Finchley.SR33/");
+				.contains("https://cloud.spring.io/spring-cloud-static/Finchley.SR33/");
 	}
 
 	@Test
@@ -165,7 +165,7 @@ public class DocumentationUpdaterTests {
 		String indexHtmlContent = new String(Files.readAllBytes(
 				new File(updatedDocs, "current/index.html").toPath()));
 		then(indexHtmlContent)
-				.contains("http://cloud.spring.io/spring-cloud-static/Finchley.SR33/");
+				.contains("https://cloud.spring.io/spring-cloud-static/Finchley.SR33/");
 	}
 
 	@Test

--- a/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/git/GithubMilestonesTests.java
+++ b/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/git/GithubMilestonesTests.java
@@ -135,7 +135,7 @@ public class GithubMilestonesTests {
 
 			@Override URL foundMilestoneUrl(Milestone.Smart milestone)
 					throws IOException {
-				return new URL("http://foo.com/bar");
+				return new URL("http://www.foo.com/bar");
 			}
 		};
 

--- a/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/sagan/RestTemplateSaganClientTests.java
+++ b/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/sagan/RestTemplateSaganClientTests.java
@@ -46,8 +46,8 @@ public class RestTemplateSaganClientTests {
 
 		then(project.id).isEqualTo("spring-framework");
 		then(project.name).isEqualTo("Spring Framework");
-		then(project.repoUrl).isEqualTo("http://github.com/spring-projects/spring-framework");
-		then(project.siteUrl).isEqualTo("http://projects.spring.io/spring-framework");
+		then(project.repoUrl).isEqualTo("https://github.com/spring-projects/spring-framework");
+		then(project.siteUrl).isEqualTo("https://projects.spring.io/spring-framework");
 		then(project.category).isEqualTo("active");
 		then(project.stackOverflowTags).isNotBlank();
 		then(project.stackOverflowTagList).isNotEmpty();
@@ -55,8 +55,8 @@ public class RestTemplateSaganClientTests {
 		then(project.projectReleases).isNotEmpty();
 		Release release = project.projectReleases.get(0);
 		then(release.releaseStatus).isEqualTo("PRERELEASE");
-		then(release.refDocUrl).isEqualTo("http://docs.spring.io/spring/docs/5.0.0.RC4/spring-framework-reference/");
-		then(release.apiDocUrl).isEqualTo("http://docs.spring.io/spring/docs/5.0.0.RC4/javadoc-api/");
+		then(release.refDocUrl).isEqualTo("https://docs.spring.io/spring/docs/5.0.0.RC4/spring-framework-reference/");
+		then(release.apiDocUrl).isEqualTo("https://docs.spring.io/spring/docs/5.0.0.RC4/javadoc-api/");
 		then(release.groupId).isEqualTo("org.springframework");
 		then(release.artifactId).isEqualTo("spring-context");
 		then(release.repository.id).isEqualTo("spring-milestones");
@@ -76,8 +76,8 @@ public class RestTemplateSaganClientTests {
 		Release release = this.client.getRelease("spring-framework", "5.0.0.RC4");
 
 		then(release.releaseStatus).isEqualTo("PRERELEASE");
-		then(release.refDocUrl).isEqualTo("http://docs.spring.io/spring/docs/{version}/spring-framework-reference/");
-		then(release.apiDocUrl).isEqualTo("http://docs.spring.io/spring/docs/{version}/javadoc-api/");
+		then(release.refDocUrl).isEqualTo("https://docs.spring.io/spring/docs/{version}/spring-framework-reference/");
+		then(release.apiDocUrl).isEqualTo("https://docs.spring.io/spring/docs/{version}/javadoc-api/");
 		then(release.groupId).isEqualTo("org.springframework");
 		then(release.artifactId).isEqualTo("spring-context");
 		then(release.repository.id).isEqualTo("spring-milestones");
@@ -110,8 +110,8 @@ public class RestTemplateSaganClientTests {
 		firstRelease.artifactId = "spring-context";
 		firstRelease.version = "1.2.8.RELEASE";
 		firstRelease.releaseStatus = "PRERELEASE";
-		firstRelease.refDocUrl = "http://docs.spring.io/spring/docs/{version}/spring-framework-reference/";
-		firstRelease.apiDocUrl = "http://docs.spring.io/spring/docs/{version}/javadoc-api/";
+		firstRelease.refDocUrl = "https://docs.spring.io/spring/docs/{version}/spring-framework-reference/";
+		firstRelease.apiDocUrl = "https://docs.spring.io/spring/docs/{version}/javadoc-api/";
 		firstRelease.repository = milestone;
 
 		ReleaseUpdate secondRelease = new ReleaseUpdate();
@@ -119,8 +119,8 @@ public class RestTemplateSaganClientTests {
 		secondRelease.artifactId = "spring-context";
 		secondRelease.version = "5.0.0.BUILD-SNAPSHOT";
 		secondRelease.releaseStatus = "SNAPSHOT";
-		secondRelease.refDocUrl = "http://docs.spring.io/spring/docs/{version}/spring-framework-reference/";
-		secondRelease.apiDocUrl = "http://docs.spring.io/spring/docs/{version}/javadoc-api/";
+		secondRelease.refDocUrl = "https://docs.spring.io/spring/docs/{version}/spring-framework-reference/";
+		secondRelease.apiDocUrl = "https://docs.spring.io/spring/docs/{version}/javadoc-api/";
 		secondRelease.repository = snapshots;
 
 		ReleaseUpdate thirdRelease = new ReleaseUpdate();
@@ -128,8 +128,8 @@ public class RestTemplateSaganClientTests {
 		thirdRelease.artifactId = "spring-context";
 		thirdRelease.version = "4.3.12.BUILD-SNAPSHOT";
 		thirdRelease.releaseStatus = "SNAPSHOT";
-		thirdRelease.refDocUrl = "http://docs.spring.io/spring/docs/{version}/spring-framework-reference/htmlsingle/";
-		thirdRelease.apiDocUrl = "http://docs.spring.io/spring/docs/{version}/javadoc-api/";
+		thirdRelease.refDocUrl = "https://docs.spring.io/spring/docs/{version}/spring-framework-reference/htmlsingle/";
+		thirdRelease.apiDocUrl = "https://docs.spring.io/spring/docs/{version}/javadoc-api/";
 		thirdRelease.repository = snapshots;
 
 		ReleaseUpdate fourthRelease = new ReleaseUpdate();
@@ -138,24 +138,24 @@ public class RestTemplateSaganClientTests {
 		fourthRelease.version = "4.3.11.RELEASE";
 		fourthRelease.releaseStatus = "GENERAL_AVAILABILITY";
 		fourthRelease.current = true;
-		fourthRelease.refDocUrl = "http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/";
-		fourthRelease.apiDocUrl = "http://docs.spring.io/spring/docs/current/javadoc-api/";
+		fourthRelease.refDocUrl = "https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/";
+		fourthRelease.apiDocUrl = "https://docs.spring.io/spring/docs/current/javadoc-api/";
 
 		ReleaseUpdate fithRelease = new ReleaseUpdate();
 		fithRelease.groupId = "org.springframework";
 		fithRelease.artifactId = "spring-context";
 		fithRelease.version = "4.2.9.RELEASE";
 		fithRelease.releaseStatus = "GENERAL_AVAILABILITY";
-		fithRelease.refDocUrl = "http://docs.spring.io/spring/docs/{version}/spring-framework-reference/htmlsingle/";
-		fithRelease.apiDocUrl = "http://docs.spring.io/spring/docs/{version}/javadoc-api/";
+		fithRelease.refDocUrl = "https://docs.spring.io/spring/docs/{version}/spring-framework-reference/htmlsingle/";
+		fithRelease.apiDocUrl = "https://docs.spring.io/spring/docs/{version}/javadoc-api/";
 
 		ReleaseUpdate sithRelease = new ReleaseUpdate();
 		sithRelease.groupId = "org.springframework";
 		sithRelease.artifactId = "spring-context";
 		sithRelease.version = "3.2.18.RELEASE";
 		sithRelease.releaseStatus = "GENERAL_AVAILABILITY";
-		sithRelease.refDocUrl = "http://docs.spring.io/spring/docs/{version}/spring-framework-reference/htmlsingle/";
-		sithRelease.apiDocUrl = "http://docs.spring.io/spring/docs/{version}/javadoc-api/";
+		sithRelease.refDocUrl = "https://docs.spring.io/spring/docs/{version}/spring-framework-reference/htmlsingle/";
+		sithRelease.apiDocUrl = "https://docs.spring.io/spring/docs/{version}/javadoc-api/";
 
 		List<ReleaseUpdate> updates = Arrays.asList(firstRelease, secondRelease, thirdRelease, fourthRelease ,fithRelease, sithRelease);
 

--- a/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/sagan/SaganUpdaterTest.java
+++ b/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/sagan/SaganUpdaterTest.java
@@ -52,7 +52,7 @@ public class SaganUpdaterTest {
 
 		then(this.saganClient).should().updateRelease(BDDMockito.eq("foo"),
 				BDDMockito.argThat(withReleaseUpdate("1.0.0.M1",
-						"http://cloud.spring.io/spring-cloud-static/foo/{version}/", "PRERELEASE")));
+						"https://cloud.spring.io/spring-cloud-static/foo/{version}/", "PRERELEASE")));
 	}
 
 	@Test public void should_update_sagan_for_rc() throws Exception {
@@ -60,7 +60,7 @@ public class SaganUpdaterTest {
 
 		then(this.saganClient).should().updateRelease(BDDMockito.eq("foo"),
 				BDDMockito.argThat(withReleaseUpdate("1.0.0.RC1",
-						"http://cloud.spring.io/spring-cloud-static/foo/{version}/", "PRERELEASE")));
+						"https://cloud.spring.io/spring-cloud-static/foo/{version}/", "PRERELEASE")));
 	}
 
 	private ProjectVersion version(String version) {
@@ -74,7 +74,7 @@ public class SaganUpdaterTest {
 
 		then(this.saganClient).should().updateRelease(BDDMockito.eq("foo"),
 				BDDMockito.argThat(withReleaseUpdate("1.0.0.BUILD-SNAPSHOT",
-						"http://cloud.spring.io/foo/foo.html", "SNAPSHOT")));
+						"https://cloud.spring.io/foo/foo.html", "SNAPSHOT")));
 	}
 
 	@Test public void should_update_sagan_from_release_version() throws Exception {
@@ -86,11 +86,11 @@ public class SaganUpdaterTest {
 		then(this.saganClient).should().deleteRelease("foo", "1.0.0.BUILD-SNAPSHOT");
 		then(this.saganClient).should().updateRelease(BDDMockito.eq("foo"),
 				BDDMockito.argThat(withReleaseUpdate("1.0.0.RELEASE",
-						"http://cloud.spring.io/spring-cloud-static/foo/{version}/", "GENERAL_AVAILABILITY")));
+						"https://cloud.spring.io/spring-cloud-static/foo/{version}/", "GENERAL_AVAILABILITY")));
 		then(this.saganClient).should().deleteRelease("foo", "1.0.0.BUILD-SNAPSHOT");
 		then(this.saganClient).should().updateRelease(BDDMockito.eq("foo"),
 				BDDMockito.argThat(withReleaseUpdate("1.0.1.BUILD-SNAPSHOT",
-						"http://cloud.spring.io/foo/foo.html", "SNAPSHOT")));
+						"https://cloud.spring.io/foo/foo.html", "SNAPSHOT")));
 	}
 
 	@Test public void should_update_sagan_from_non_master() throws Exception {
@@ -101,7 +101,7 @@ public class SaganUpdaterTest {
 		then(this.saganClient).should(never()).deleteRelease(anyString(), anyString());
 		then(this.saganClient).should().updateRelease(BDDMockito.eq("foo"),
 				BDDMockito.argThat(withReleaseUpdate("1.1.0.BUILD-SNAPSHOT",
-						"http://cloud.spring.io/foo/1.1.x/", "SNAPSHOT")));
+						"https://cloud.spring.io/foo/1.1.x/", "SNAPSHOT")));
 	}
 
 	private ArgumentMatcher<List<ReleaseUpdate>> withReleaseUpdate(final String version,

--- a/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/template/TemplateGeneratorTests.java
+++ b/spring-cloud-release-tools-core/src/test/java/org/springframework/cloud/release/internal/template/TemplateGeneratorTests.java
@@ -174,7 +174,7 @@ public class TemplateGeneratorTests {
 				.contains("### Spring Cloud Sleuth")
 				.contains("| Spring Cloud Sleuth        \t| 1.0.0.M1  \t|")
 				.contains("<id>spring-milestones</id>")
-				.contains("url 'http://repo.spring.io/milestone'")
+				.contains("url 'https://repo.spring.io/milestone'")
 				.contains("<version>Dalston.M1</version>")
 				.contains("mavenBom 'org.springframework.cloud:spring-cloud-dependencies:Dalston.M1'");
 	}
@@ -198,7 +198,7 @@ public class TemplateGeneratorTests {
 				.contains("### Spring Cloud Sleuth")
 				.contains("| Spring Cloud Sleuth        \t| 1.0.0.M1  \t|")
 				.contains("<id>spring-milestones</id>")
-				.contains("url 'http://repo.spring.io/milestone'")
+				.contains("url 'https://repo.spring.io/milestone'")
 				.contains("<version>Dalston.M1</version>")
 				.contains("mavenBom 'org.springframework.cloud:spring-cloud-dependencies:Dalston.M1'");
 	}
@@ -222,7 +222,7 @@ public class TemplateGeneratorTests {
 				.contains("### Spring Cloud Sleuth")
 				.contains("| Spring Cloud Sleuth        \t| 1.0.0.RC1  \t|")
 				.contains("<id>spring-milestones</id>")
-				.contains("url 'http://repo.spring.io/milestone'")
+				.contains("url 'https://repo.spring.io/milestone'")
 				.contains("<version>Dalston.RC1</version>")
 				.contains("mavenBom 'org.springframework.cloud:spring-cloud-dependencies:Dalston.RC1'");
 	}
@@ -246,7 +246,7 @@ public class TemplateGeneratorTests {
 				.contains("### Spring Cloud Sleuth")
 				.contains("| Spring Cloud Sleuth        \t| 1.0.0.RC1  \t|")
 				.contains("<id>spring-milestones</id>")
-				.contains("url 'http://repo.spring.io/milestone'")
+				.contains("url 'https://repo.spring.io/milestone'")
 				.contains("<version>Dalston.RC1</version>")
 				.contains("mavenBom 'org.springframework.cloud:spring-cloud-dependencies:Dalston.RC1'");
 	}
@@ -256,7 +256,7 @@ public class TemplateGeneratorTests {
 			throws IOException {
 		ProjectGitHandler handler = new ProjectGitHandler(this.props) {
 			@Override public String milestoneUrl(ProjectVersion releaseVersion) {
-				return "http://foo.bar.com?closed=1";
+				return "https://foo.bar.com?closed=1";
 			}
 		};
 		this.props.getPom().setBranch("Dalston.RC1");
@@ -272,8 +272,8 @@ public class TemplateGeneratorTests {
 
 		then(content(generatedOutput))
 				.contains("# Dalston.RC1")
-				.contains("Spring Cloud Sleuth `1.0.0.RC1` ([issues](http://foo.bar.com?closed=1))")
-				.contains("Spring Cloud Consul `1.0.1.RC1` ([issues](http://foo.bar.com?closed=1))")
+				.contains("Spring Cloud Sleuth `1.0.0.RC1` ([issues](https://foo.bar.com?closed=1))")
+				.contains("Spring Cloud Consul `1.0.1.RC1` ([issues](https://foo.bar.com?closed=1))")
 				.doesNotContain("Boot");
 	}
 

--- a/spring-cloud-release-tools-core/src/test/resources/projects/spring-cloud-release/README.adoc
+++ b/spring-cloud-release-tools-core/src/test/resources/projects/spring-cloud-release/README.adoc
@@ -38,7 +38,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -51,7 +51,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/spring-cloud-release-tools-core/src/test/resources/projects/spring-cloud-static/current/index.html
+++ b/spring-cloud-release-tools-core/src/test/resources/projects/spring-cloud-static/current/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
 
 <meta charset="UTF-8">
-<meta http-equiv="refresh" content="1; url=http://cloud.spring.io/spring-cloud-static/Dalston.SR3/">
+<meta http-equiv="refresh" content="1; url=https://cloud.spring.io/spring-cloud-static/Dalston.SR3/">
 
 <script>
-  window.location.href = "http://cloud.spring.io/spring-cloud-static/Dalston.SR3/"
+  window.location.href = "https://cloud.spring.io/spring-cloud-static/Dalston.SR3/"
 </script>
 
 <title>Page Redirection</title>
 
 <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-If you are not redirected automatically, follow the <a href='http://cloud.spring.io/spring-cloud-static/Dalston.SR3/'>link to latest release</a>
+If you are not redirected automatically, follow the <a href='https://cloud.spring.io/spring-cloud-static/Dalston.SR3/'>link to latest release</a>

--- a/spring-cloud-release-tools-spring/src/test/java/org/springframework/cloud/release/internal/docs/TestDocumentationUpdater.java
+++ b/spring-cloud-release-tools-spring/src/test/java/org/springframework/cloud/release/internal/docs/TestDocumentationUpdater.java
@@ -28,15 +28,15 @@ public class TestDocumentationUpdater extends DocumentationUpdater {
 		return "<!DOCTYPE HTML>\n"
 				+ "\n"
 				+ "<meta charset=\"UTF-8\">\n"
-				+ "<meta http-equiv=\"refresh\" content=\"1; url=http://cloud.spring.io/spring-cloud-static/" + this.version + "/\">\n"
+				+ "<meta http-equiv=\"refresh\" content=\"1; url=https://cloud.spring.io/spring-cloud-static/" + this.version + "/\">\n"
 				+ "\n"
 				+ "<script>\n"
-				+ "  window.location.href = \"http://cloud.spring.io/spring-cloud-static/" + this.version + "/\"\n"
+				+ "  window.location.href = \"https://cloud.spring.io/spring-cloud-static/" + this.version + "/\"\n"
 				+ "</script>\n"
 				+ "\n"
 				+ "<title>Page Redirection</title>\n"
 				+ "\n"
 				+ "<!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->\n"
-				+ "If you are not redirected automatically, follow the <a href='http://cloud.spring.io/spring-cloud-static/" + this.version + "/'>link to latest release</a>\n";
+				+ "If you are not redirected automatically, follow the <a href='https://cloud.spring.io/spring-cloud-static/" + this.version + "/'>link to latest release</a>\n";
 	}
 }

--- a/spring-cloud-release-tools-spring/src/test/java/org/springframework/cloud/release/internal/spring/AcceptanceTests.java
+++ b/spring-cloud-release-tools-spring/src/test/java/org/springframework/cloud/release/internal/spring/AcceptanceTests.java
@@ -171,8 +171,8 @@ public class AcceptanceTests {
 		then(releaseNotesTemplate()).exists();
 		then(releaseNotesTemplateContents())
 				.contains("Camden.SR5")
-				.contains("- Spring Cloud Config `1.2.2.RELEASE` ([issues](http://foo.bar.com/1.2.2.RELEASE))")
-				.contains("- Spring Cloud Aws `1.1.3.RELEASE` ([issues](http://foo.bar.com/1.1.3.RELEASE))");
+				.contains("- Spring Cloud Config `1.2.2.RELEASE` ([issues](https://foo.bar.com/1.2.2.RELEASE))")
+				.contains("- Spring Cloud Aws `1.1.3.RELEASE` ([issues](https://foo.bar.com/1.1.3.RELEASE))");
 		// once for updating GA
 		// second time to update SNAPSHOT
 		BDDMockito.then(this.saganClient).should(BDDMockito.times(2)).updateRelease(BDDMockito.eq("spring-cloud-consul"),
@@ -404,8 +404,8 @@ public class AcceptanceTests {
 		then(releaseNotesTemplate()).exists();
 		then(releaseNotesTemplateContents())
 				.contains("Dalston.RC1")
-				.contains("- Spring Cloud Build `1.3.1.RELEASE` ([issues](http://foo.bar.com/1.3.1.RELEASE))")
-				.contains("- Spring Cloud Bus `1.3.0.M1` ([issues](http://foo.bar.com/1.3.0.M1))");
+				.contains("- Spring Cloud Build `1.3.1.RELEASE` ([issues](https://foo.bar.com/1.3.1.RELEASE))")
+				.contains("- Spring Cloud Bus `1.3.0.M1` ([issues](https://foo.bar.com/1.3.0.M1))");
 		BDDMockito.then(this.saganClient).should().updateRelease(BDDMockito.eq("spring-cloud-consul"),
 				BDDMockito.anyList());
 		BDDMockito.then(this.saganClient).should()
@@ -444,8 +444,8 @@ public class AcceptanceTests {
 		then(releaseNotesTemplate()).exists();
 		then(releaseNotesTemplateContents())
 				.contains("Dalston.RC1")
-				.contains("- Spring Cloud Build `1.3.1.RELEASE` ([issues](http://foo.bar.com/1.3.1.RELEASE))")
-				.contains("- Spring Cloud Bus `1.3.0.M1` ([issues](http://foo.bar.com/1.3.0.M1)");
+				.contains("- Spring Cloud Build `1.3.1.RELEASE` ([issues](https://foo.bar.com/1.3.1.RELEASE))")
+				.contains("- Spring Cloud Bus `1.3.0.M1` ([issues](https://foo.bar.com/1.3.0.M1)");
 		BDDMockito.then(this.saganClient).should(BDDMockito.never()).updateRelease(
 				BDDMockito.anyString(), BDDMockito.anyList());
 		then(this.gitHandler.issueCreatedInSpringGuides).isFalse();
@@ -698,7 +698,7 @@ public class AcceptanceTests {
 		}
 
 		@Override public String milestoneUrl(ProjectVersion releaseVersion) {
-			return "http://foo.bar.com/" + releaseVersion.toString();
+			return "https://foo.bar.com/" + releaseVersion.toString();
 		}
 	}
 
@@ -722,7 +722,7 @@ public class AcceptanceTests {
 		}
 
 		@Override public String milestoneUrl(ProjectVersion releaseVersion) {
-			return "http://foo.bar.com/" + releaseVersion.toString();
+			return "https://foo.bar.com/" + releaseVersion.toString();
 		}
 
 		@Override public File cloneReleaseTrainProject() {

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/README.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/README.adoc
@@ -70,7 +70,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -83,7 +83,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/building-base.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/building-base.adoc
@@ -31,7 +31,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -53,13 +53,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/building-lombok.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/building-lombok.adoc
@@ -1,6 +1,6 @@
 ==== Adding Project Lombok Agent
 
-Spring Cloud uses http://projectlombok.org/features/index.html[Project Lombok]
+Spring Cloud uses https://projectlombok.org/features/index.html[Project Lombok]
 to generate getters and setters etc. Compiling from the command line this
 shouldn't cause any problems, but in an IDE you need to add an agent
 to the JVM. Full instructions can be found in the Lombok website. The

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/code-of-conduct.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/code-of-conduct.adoc
@@ -41,5 +41,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/contributing.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/asciidoc/contributing.adoc
@@ -26,7 +26,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -39,6 +39,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-build/docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-release-with-snapshot/README.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-release-with-snapshot/README.adoc
@@ -38,7 +38,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -51,7 +51,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-release/README.adoc
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-release/README.adoc
@@ -38,7 +38,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -51,7 +51,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-static-angel/current/index.html
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-static-angel/current/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
 
 <meta charset="UTF-8">
-<meta http-equiv="refresh" content="1; url=http://cloud.spring.io/spring-cloud-static/Dalston.SR3/">
+<meta http-equiv="refresh" content="1; url=https://cloud.spring.io/spring-cloud-static/Dalston.SR3/">
 
 <script>
-  window.location.href = "http://cloud.spring.io/spring-cloud-static/Dalston.SR3/"
+  window.location.href = "https://cloud.spring.io/spring-cloud-static/Dalston.SR3/"
 </script>
 
 <title>Page Redirection</title>
 
 <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-If you are not redirected automatically, follow the <a href='http://cloud.spring.io/spring-cloud-static/Dalston.SR3/'>link to latest release</a>
+If you are not redirected automatically, follow the <a href='https://cloud.spring.io/spring-cloud-static/Dalston.SR3/'>link to latest release</a>

--- a/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-static/current/index.html
+++ b/spring-cloud-release-tools-spring/src/test/resources/projects/spring-cloud-static/current/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
 
 <meta charset="UTF-8">
-<meta http-equiv="refresh" content="1; url=http://cloud.spring.io/spring-cloud-static/Dalston.SR3/">
+<meta http-equiv="refresh" content="1; url=https://cloud.spring.io/spring-cloud-static/Dalston.SR3/">
 
 <script>
-  window.location.href = "http://cloud.spring.io/spring-cloud-static/Dalston.SR3/"
+  window.location.href = "https://cloud.spring.io/spring-cloud-static/Dalston.SR3/"
 </script>
 
 <title>Page Redirection</title>
 
 <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
-If you are not redirected automatically, follow the <a href='http://cloud.spring.io/spring-cloud-static/Dalston.SR3/'>link to latest release</a>
+If you are not redirected automatically, follow the <a href='https://cloud.spring.io/spring-cloud-static/Dalston.SR3/'>link to latest release</a>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://foo.com/bar (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com/bar) result SSLHandshakeException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://foo.bar.com/ (UnknownHostException) with 2 occurrences migrated to:  
  https://foo.bar.com/ ([https](https://foo.bar.com/) result UnknownHostException).
* [ ] http://foo.bar.com/1.1.3.RELEASE (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.bar.com/1.1.3.RELEASE ([https](https://foo.bar.com/1.1.3.RELEASE) result UnknownHostException).
* [ ] http://foo.bar.com/1.2.2.RELEASE (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.bar.com/1.2.2.RELEASE ([https](https://foo.bar.com/1.2.2.RELEASE) result UnknownHostException).
* [ ] http://foo.bar.com/1.3.0.M1 (UnknownHostException) with 2 occurrences migrated to:  
  https://foo.bar.com/1.3.0.M1 ([https](https://foo.bar.com/1.3.0.M1) result UnknownHostException).
* [ ] http://foo.bar.com/1.3.1.RELEASE (UnknownHostException) with 2 occurrences migrated to:  
  https://foo.bar.com/1.3.1.RELEASE ([https](https://foo.bar.com/1.3.1.RELEASE) result UnknownHostException).
* [ ] http://foo.bar.com?closed=1 (UnknownHostException) with 3 occurrences migrated to:  
  https://foo.bar.com?closed=1 ([https](https://foo.bar.com?closed=1) result UnknownHostException).
* [ ] http://cloud.spring.io/foo/1.1.x/ (404) with 1 occurrences migrated to:  
  https://cloud.spring.io/foo/1.1.x/ ([https](https://cloud.spring.io/foo/1.1.x/) result 404).
* [ ] http://cloud.spring.io/foo/foo.html (404) with 2 occurrences migrated to:  
  https://cloud.spring.io/foo/foo.html ([https](https://cloud.spring.io/foo/foo.html) result 404).
* [ ] http://cloud.spring.io/spring-cloud-static/Angel.SR33/ (404) with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Angel.SR33/ ([https](https://cloud.spring.io/spring-cloud-static/Angel.SR33/) result 404).
* [ ] http://cloud.spring.io/spring-cloud-static/Dalston.SR3/ (404) with 9 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Dalston.SR3/ ([https](https://cloud.spring.io/spring-cloud-static/Dalston.SR3/) result 404).
* [ ] http://cloud.spring.io/spring-cloud-static/Finchley.SR33/ (404) with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Finchley.SR33/ ([https](https://cloud.spring.io/spring-cloud-static/Finchley.SR33/) result 404).
* [ ] http://cloud.spring.io/spring-cloud-static/foo/ (404) with 3 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/foo/ ([https](https://cloud.spring.io/spring-cloud-static/foo/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/ with 2 occurrences migrated to:  
  https://cloud.spring.io/ ([https](https://cloud.spring.io/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-static/ with 5 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/ ([https](https://cloud.spring.io/spring-cloud-static/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 12 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/5.0.0.RC4/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.0.RC4/javadoc-api/ ([https](https://docs.spring.io/spring/docs/5.0.0.RC4/javadoc-api/) result 200).
* [ ] http://docs.spring.io/spring/docs/5.0.0.RC4/spring-framework-reference/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.0.RC4/spring-framework-reference/ ([https](https://docs.spring.io/spring/docs/5.0.0.RC4/spring-framework-reference/) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* [ ] http://github.com/ with 2 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://github.com/spring-projects/spring-framework with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-framework ([https](https://github.com/spring-projects/spring-framework) result 200).
* [ ] http://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar with 4 occurrences migrated to:  
  https://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar ([https](https://repo.spring.io/libs-milestone/org/springframework/cloud/internal/spring-cloud-release-tools-spring/1.0.0.M1/spring-cloud-release-tools-spring-1.0.0.M1.jar) result 200).
* [ ] http://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/ with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/ ([https](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/) result 200).
* [ ] http://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/Dalston.RELEASE/ with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/Dalston.RELEASE/ ([https](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/Dalston.RELEASE/) result 200).
* [ ] http://spring.io with 2 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-cloud with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-cloud ([https](https://stackoverflow.com/questions/tagged/spring-cloud) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 5 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 5 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projectlombok.org/features/index.html with 1 occurrences migrated to:  
  https://projectlombok.org/features/index.html ([https](https://projectlombok.org/features/index.html) result 301).
* [ ] http://projects.spring.io/spring-framework with 1 occurrences migrated to:  
  https://projects.spring.io/spring-framework ([https](https://projects.spring.io/spring-framework) result 301).
* [ ] http://raw.github.com/ with 2 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 302).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://repo.spring.io/milestone with 6 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences