### PR TITLE
Allow live output + output capture thanks to zt-exec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<javax.json.version>1.0.4</javax.json.version>
 		<jopt-simple.version>5.0.3</jopt-simple.version>
 		<fliptables.version>1.0.2</fliptables.version>
+		<zt.exec.version>1.11</zt.exec.version>
 	</properties>
 
 	<dependencyManagement>

--- a/releaser-core/pom.xml
+++ b/releaser-core/pom.xml
@@ -135,6 +135,11 @@
 			<version>${javax.json.version}</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.zeroturnaround</groupId>
+			<artifactId>zt-exec</artifactId>
+			<version>${zt.exec.version}</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>


### PR DESCRIPTION
Switching to this utility allows proper capture of the command's output while also forwarding output to the logger, so that CI sees activity.