### PR TITLE
Updates to use spring-boot-starter-parent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ nbdist/
 *.log
 _site
 effective.pom
+
+.sdkmanrc

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
 	<packaging>pom</packaging>
 
 	<parent>
-		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-build</artifactId>
-		<version>2.2.3.RELEASE</version>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.3.2.RELEASE</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -30,17 +30,19 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 
-		<spring-cloud-bom.version>Hoxton.BUILD-SNAPSHOT</spring-cloud-bom.version>
+		<spring-cloud-bom.version>Hoxton.SR6</spring-cloud-bom.version>
 		<jcabi-github.version>1.0</jcabi-github.version>
 		<jsch-agent.version>0.0.9</jsch-agent.version>
-		<hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
 		<org.eclipse.jgit-version>5.1.3.201810200350-r</org.eclipse.jgit-version>
 		<!-- Versions plugin uses this version -->
-		<maven-model.version>2.2.1</maven-model.version>
-		<versions-maven-plugin.version>2.3</versions-maven-plugin.version>
-		<handlebars.version>4.0.6</handlebars.version>
-		<initializr-metadata.version>0.8.0.BUILD-SNAPSHOT</initializr-metadata.version>
-		<awaitility.version>3.1.6</awaitility.version>
+		<asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>
+		<spring-asciidoctor-extensions.version>0.2.0.RELEASE
+		</spring-asciidoctor-extensions.version>
+		<maven-model.version>3.6.3</maven-model.version>
+		<versions-maven-plugin.version>2.7</versions-maven-plugin.version>
+		<handlebars.version>4.2.0</handlebars.version>
+		<initializr-metadata.version>0.10.0-SNAPSHOT</initializr-metadata.version>
+		<awaitility.version>4.0.3</awaitility.version>
 		<sagan-site.version>1.0.0.BUILD-SNAPSHOT</sagan-site.version>
 		<javax.json.version>1.0.4</javax.json.version>
 		<jopt-simple.version>5.0.3</jopt-simple.version>

--- a/releaser-core/pom.xml
+++ b/releaser-core/pom.xml
@@ -33,11 +33,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<version>${hibernate-validator.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>${org.eclipse.jgit-version}</version>
@@ -102,6 +97,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/releaser-core/src/test/java/releaser/internal/ReleaserTests.java
+++ b/releaser-core/src/test/java/releaser/internal/ReleaserTests.java
@@ -42,7 +42,7 @@ import releaser.internal.project.Projects;
 import releaser.internal.sagan.SaganUpdater;
 import releaser.internal.template.TemplateGenerator;
 
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.never;
 public class ReleaserTests {
 
 	@Rule
-	public OutputCapture outputCapture = new OutputCapture();
+	public OutputCaptureRule outputCapture = new OutputCaptureRule();
 
 	@Mock
 	ProjectPomUpdater projectPomUpdater;

--- a/releaser-core/src/test/java/releaser/internal/buildsystem/PomUpdaterTests.java
+++ b/releaser-core/src/test/java/releaser/internal/buildsystem/PomUpdaterTests.java
@@ -35,7 +35,7 @@ import releaser.internal.git.GitRepoTests;
 import releaser.internal.project.Project;
 import releaser.internal.tech.PomReader;
 
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 import org.springframework.util.FileSystemUtils;
 
 /**
@@ -44,7 +44,7 @@ import org.springframework.util.FileSystemUtils;
 public class PomUpdaterTests {
 
 	@Rule
-	public OutputCapture capture = new OutputCapture();
+	public OutputCaptureRule capture = new OutputCaptureRule();
 
 	@Rule
 	public TemporaryFolder tmp = new TemporaryFolder();

--- a/releaser-core/src/test/java/releaser/internal/docs/SpringCloudGhPagesParserTests.java
+++ b/releaser-core/src/test/java/releaser/internal/docs/SpringCloudGhPagesParserTests.java
@@ -23,7 +23,7 @@ import org.assertj.core.api.BDDAssertions;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 
 /**
  * @author Marcin Grzejszczak
@@ -31,7 +31,7 @@ import org.springframework.boot.test.rule.OutputCapture;
 public class SpringCloudGhPagesParserTests {
 
 	@Rule
-	public OutputCapture capture = new OutputCapture();
+	public OutputCaptureRule capture = new OutputCaptureRule();
 
 	File rawHtml = new File(SpringCloudGhPagesParserTests.class
 			.getResource("/raw/spring-cloud-gh-pages-index.html").toURI());

--- a/releaser-core/src/test/java/releaser/internal/github/GithubIssuesTests.java
+++ b/releaser-core/src/test/java/releaser/internal/github/GithubIssuesTests.java
@@ -31,7 +31,7 @@ import org.mockito.BDDMockito;
 import releaser.internal.project.ProjectVersion;
 import releaser.internal.project.Projects;
 
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 
 /**
  * @author Marcin Grzejszczak
@@ -42,7 +42,7 @@ public class GithubIssuesTests {
 	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Rule
-	public OutputCapture capture = new OutputCapture();
+	public OutputCaptureRule capture = new OutputCaptureRule();
 
 	MkGithub github;
 

--- a/releaser-core/src/test/java/releaser/internal/github/GithubMilestonesTests.java
+++ b/releaser-core/src/test/java/releaser/internal/github/GithubMilestonesTests.java
@@ -30,7 +30,7 @@ import org.junit.rules.TemporaryFolder;
 import releaser.internal.ReleaserProperties;
 import releaser.internal.project.ProjectVersion;
 
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
@@ -44,7 +44,7 @@ public class GithubMilestonesTests {
 	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Rule
-	public OutputCapture capture = new OutputCapture();
+	public OutputCaptureRule capture = new OutputCaptureRule();
 
 	MkGithub github;
 

--- a/releaser-core/src/test/java/releaser/internal/project/ProjectCommandExecutorTests.java
+++ b/releaser-core/src/test/java/releaser/internal/project/ProjectCommandExecutorTests.java
@@ -36,7 +36,7 @@ import releaser.internal.PomUpdateAcceptanceTests;
 import releaser.internal.ReleaserProperties;
 import releaser.internal.buildsystem.TestUtils;
 
-import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.boot.test.system.OutputCaptureRule;
 import org.springframework.util.FileSystemUtils;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -51,7 +51,7 @@ public class ProjectCommandExecutorTests {
 	public TemporaryFolder tmp = new TemporaryFolder();
 
 	@Rule
-	public OutputCapture outputCapture = new OutputCapture();
+	public OutputCaptureRule outputCapture = new OutputCaptureRule();
 
 	File temporaryFolder;
 

--- a/releaser-spring/pom.xml
+++ b/releaser-spring/pom.xml
@@ -59,6 +59,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/releaser-test/pom.xml
+++ b/releaser-test/pom.xml
@@ -40,6 +40,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/spring-cloud-info/pom.xml
+++ b/spring-cloud-info/pom.xml
@@ -65,6 +65,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.restdocs</groupId>
 			<artifactId>spring-restdocs-mockmvc</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
Rather than spring-cloud-build. This eliminates some potential weirdness in using the thing we're building.

This should only be merged after Hoxton.SR7