### PR TITLE
Clone release train doc project for non-release

### DIFF
--- a/releaser-core/src/main/java/releaser/internal/postrelease/PostReleaseActions.java
+++ b/releaser-core/src/main/java/releaser/internal/postrelease/PostReleaseActions.java
@@ -317,8 +317,16 @@ public class PostReleaseActions implements Closeable {
 			return ExecutionResult.skipped();
 		}
 		ProjectVersion releaseTrain = projects.releaseTrain(this.properties);
-		File file = this.projectGitHandler
-				.cloneReleaseTrainDocumentationProject(releaseTrain.releaseTagName());
+		File file;
+		String branch = releaseTrain.releaseTagName();
+		if (StringUtils.hasText(branch)) {
+			file = this.projectGitHandler
+					.cloneReleaseTrainDocumentationProject(branch);
+		}
+		else {
+			// this is a milestone or snapshot, not a release
+			file = this.projectGitHandler.cloneReleaseTrainDocumentationProject();
+		}
 		ReleaserProperties projectProps = projectProps(file);
 		String releaseTrainVersion = releaseTrain.version;
 		this.projectCommandExecutor.generateReleaseTrainDocs(projectProps,


### PR DESCRIPTION
If `releaseTrain.releaseTagName()` is empty use `projectGitHandler.cloneReleaseTrainDocumentationProject()` to clone docs.