### PR TITLE
Update Sagan project docs URL for antora docs

### DIFF
--- a/releaser-core/src/main/java/releaser/internal/sagan/ReleaseInput.java
+++ b/releaser-core/src/main/java/releaser/internal/sagan/ReleaseInput.java
@@ -32,6 +32,8 @@ public class ReleaseInput {
 
 	private String apiDocUrl = "";
 
+	private boolean isAntora = true;
+
 	public String getVersion() {
 		return this.version;
 	}
@@ -56,10 +58,18 @@ public class ReleaseInput {
 		this.apiDocUrl = apiDocUrl;
 	}
 
+	public boolean isAntora() {
+		return this.isAntora;
+	}
+
+	public void setAntora(boolean antora) {
+		this.isAntora = antora;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("version", version).append("referenceDocUrl", referenceDocUrl)
-				.append("apiDocUrl", apiDocUrl).toString();
+				.append("apiDocUrl", apiDocUrl).append("isAntora", isAntora).toString();
 
 	}
 

--- a/releaser-core/src/main/java/releaser/internal/sagan/RestTemplateSaganClient.java
+++ b/releaser-core/src/main/java/releaser/internal/sagan/RestTemplateSaganClient.java
@@ -87,6 +87,7 @@ class RestTemplateSaganClient implements SaganClient {
 		RequestEntity<ReleaseInput> request = RequestEntity
 				.post(URI.create(this.baseUrl + "/projects/" + projectName + "/releases"))
 				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE).body(releaseInput);
+		log.info("Request to Sagans\n\n[{}]", request);
 		ResponseEntity<Project> entity = this.restTemplate.exchange(request, Project.class);
 		boolean added = entity.getStatusCode().is2xxSuccessful();
 		log.info("Response from Sagan\n\n[{}]", entity);

--- a/releaser-core/src/main/java/releaser/internal/sagan/SaganUpdater.java
+++ b/releaser-core/src/main/java/releaser/internal/sagan/SaganUpdater.java
@@ -207,7 +207,18 @@ public class SaganUpdater {
 	}
 
 	private String newReferenceUrl(ProjectVersion version) {
-		return "https://docs.spring.io/" + version.projectName + "/docs/{version}/reference/html/";
+		String antoraVersions = version.majorAndMinor();
+		if (version.isSnapshot()) {
+			antoraVersions += "-SNAPSHOT";
+		}
+		//TODO uncomment the below line and remove the logic above once Contentful "Antora Version" checkbox
+		// bug is fixed.  Currently the checkbox is not being saved and is always unchecked when using the REST API
+		// and this results in the version now being computed propertly by Contentful.  Therefore we compute the version
+		// in the documentation URL ourselves instead of using the {version} placeholder and letting Contentful compute the
+		// version.  NOTE: Tests in {@link SaganUpdaterTests} will need to be updated as well once the fix is in place.
+		// return "https://docs.spring.io/" + version.projectName +
+		// "/reference/{version}/";
+		return "https://docs.spring.io/" + version.projectName + "/reference/" + antoraVersions + "/";
 	}
 
 }

--- a/releaser-core/src/test/java/releaser/internal/sagan/SaganUpdaterTest.java
+++ b/releaser-core/src/test/java/releaser/internal/sagan/SaganUpdaterTest.java
@@ -93,7 +93,7 @@ public class SaganUpdaterTest {
 		assertThat(result.isSuccess()).isTrue();
 
 		then(this.saganClient).should().addRelease(eq("foo"),
-				argThat(withReleaseUpdate("2.2.0-M1", "https://docs.spring.io/foo/docs/{version}/reference/html/")));
+				argThat(withReleaseUpdate("2.2.0-M1", "https://docs.spring.io/foo/reference/2.2/")));
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class SaganUpdaterTest {
 		assertThat(result.isSuccess()).isTrue();
 
 		then(this.saganClient).should().addRelease(eq("foo"),
-				argThat(withReleaseUpdate("2.2.0-RC1", "https://docs.spring.io/foo/docs/{version}/reference/html/")));
+				argThat(withReleaseUpdate("2.2.0-RC1", "https://docs.spring.io/foo/reference/2.2/")));
 	}
 
 	@Test
@@ -219,8 +219,8 @@ public class SaganUpdaterTest {
 		// FIXME: assertThat(result.isSkipped()).isFalse();
 		assertThat(result.isSuccess()).isTrue();
 
-		then(this.saganClient).should().addRelease(eq("foo"), argThat(
-				withReleaseUpdate("2.4.0-SNAPSHOT", "https://docs.spring.io/foo/docs/{version}/reference/html/")));
+		then(this.saganClient).should().addRelease(eq("foo"),
+				argThat(withReleaseUpdate("2.4.0-SNAPSHOT", "https://docs.spring.io/foo/reference/2.4-SNAPSHOT/")));
 	}
 
 	@Test
@@ -240,10 +240,10 @@ public class SaganUpdaterTest {
 		then(this.saganClient).should().deleteRelease("foo", "2.2.0-RC1");
 		then(this.saganClient).should().deleteRelease("foo", "2.2.0-SNAPSHOT");
 		then(this.saganClient).should().addRelease(eq("foo"),
-				argThat(withReleaseUpdate("2.2.0", "https://docs.spring.io/foo/docs/{version}/reference/html/")));
+				argThat(withReleaseUpdate("2.2.0", "https://docs.spring.io/foo/reference/2.2/")));
 		then(this.saganClient).should().deleteRelease("foo", "2.2.0-SNAPSHOT");
-		then(this.saganClient).should().addRelease(eq("foo"), argThat(
-				withReleaseUpdate("2.2.1-SNAPSHOT", "https://docs.spring.io/foo/docs/{version}/reference/html/")));
+		then(this.saganClient).should().addRelease(eq("foo"),
+				argThat(withReleaseUpdate("2.2.1-SNAPSHOT", "https://docs.spring.io/foo/reference/2.2-SNAPSHOT/")));
 	}
 
 	@Test
@@ -258,8 +258,8 @@ public class SaganUpdaterTest {
 		assertThat(result.isSuccess()).isTrue();
 
 		then(this.saganClient).should(never()).deleteRelease(anyString(), anyString());
-		then(this.saganClient).should().addRelease(eq("foo"), argThat(
-				withReleaseUpdate("2.3.0-SNAPSHOT", "https://docs.spring.io/foo/docs/{version}/reference/html/")));
+		then(this.saganClient).should().addRelease(eq("foo"),
+				argThat(withReleaseUpdate("2.3.0-SNAPSHOT", "https://docs.spring.io/foo/reference/2.3-SNAPSHOT/")));
 	}
 
 	private Project projectWithNewRelease(String version) {


### PR DESCRIPTION
This change updates the documentation links when doing a release to using the Antora docs.

Ideally we would use the `{version}` placeholder but there appears to be a bug in Contentful that does not honor the `isAntora` flag in the POST body of the request to update the documentation.  Without the `isAntora` flag set Contentful will  not compute the version for the URL correctly leading to broken links.  

Luckily we can compute the version for the Antora docs ourselves and just create the entire URL without the `{version}` placeholder.